### PR TITLE
Root user images varient

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,19 +20,6 @@ commands:
           docker-compose push php-<< parameters.variant >> php-<< parameters.variant >>-xdebug
 
 jobs:
-  build_71_fpm:
-    machine: true
-    working_directory: ~/psg-docker-php/
-    steps:
-      - build_and_push:
-          variant: '71-fpm'
-  build_71_cli:
-    machine: true
-    working_directory: ~/psg-docker-php/
-    steps:
-      - build_and_push:
-          variant: '71-cli'
-
   build_72_fpm:
     machine: true
     working_directory: ~/psg-docker-php/
@@ -63,8 +50,6 @@ workflows:
   version: 2
   btd:
     jobs:
-      - build_71_fpm
-      - build_71_cli
       - build_72_fpm
       - build_72_cli
       - build_73_fpm

--- a/README.md
+++ b/README.md
@@ -8,12 +8,21 @@ These images are designed to be used in production, as well as in a staging envi
 
 Available tags:
 
-- playsportsgroup/php:7.1-fpm-alpine
-- playsportsgroup/php:7.1-cli-alpine
+ These images run as non-root user `app` by default:
 - playsportsgroup/php:7.2-fpm-alpine
 - playsportsgroup/php:7.2-cli-alpine
+- playsportsgroup/php:7.3-fpm-alpine
+- playsportsgroup/php:7.3-cli-alpine
+
+These images run as the root user by default:
+- playsportsgroup/php:7.2-fpm-alpine-root
+- playsportsgroup/php:7.2-cli-alpine-root
+- playsportsgroup/php:7.3-fpm-alpine-root
+- playsportsgroup/php:7.3-cli-alpine-root
 
 Deprecated tags (only alpine is being actively developed):
+- playsportsgroup/php:7.1-fpm-alpine
+- playsportsgroup/php:7.1-cli-alpine
 - playsportsgroup/php:7.1-fpm
 - playsportsgroup/php:7.1-cli
 - playsportsgroup/php:7.2-fpm
@@ -25,7 +34,7 @@ Deprecated tags (only alpine is being actively developed):
 
 ## How to add additional packages in your own dockerfile:
 
-You will need to reconfigure to use the `root` user, then switch back afterwards to the `app` user.
+If you're using a non-root image you will need to reconfigure to use the `root` user, then switch back afterwards to the `app` user.
 
     FROM playsportsgroup/php:7.2-fpm-alpine
 
@@ -35,7 +44,7 @@ You will need to reconfigure to use the `root` user, then switch back afterwards
 
 ## What PHP extensions come out of the box?
 
-- xdebug (but it's disabled, you'll need to enable it manually!)
+- xdebug (disabled, you'll need to enable it)
 - gd
 - intl
 - mbstring
@@ -48,20 +57,15 @@ You will need to reconfigure to use the `root` user, then switch back afterwards
 - mcrypt
 - pcntl
 - apcu
+- imagick
 
-My goal is to provide some commonly used extensions, and speed up build times by not needing to recompile PHP multiple times.
+Our goal is to provide some commonly used extensions, and speed up build times by not needing to recompile PHP multiple times.
 
 ## What else is there?
 
-Composer, of course!
+Composer is included
 
-## Why do you use an `app` user instead of root?
-
-TL;DR; Security.
-
-Read up on it here: [Processes in containers should not run as root](https://medium.com/@mccode/processes-in-containers-should-not-run-as-root-2feae3f0df3b)
-
-## So how can I use this!?
+## So how can I use these images?
 
     docker run playsportsgroup/php:7.2-fpm-alpine-v $(pwd):/var/www/html -p 9000:9000 --name myawesomephpapp
 
@@ -103,11 +107,11 @@ Want to run one of commands?
 
 opcache is enabled by default!
 
-For local development I recommend setting the `$PHP_OPCACHE_VALIDATE_TIMESTAMPS` environment variable to a value of `1`. For production, leave it as `0`.
+For local development we recommend setting the `$PHP_OPCACHE_VALIDATE_TIMESTAMPS` environment variable to a value of `1`. For production, leave it as `0`.
 
     docker run -e PHP_OPCACHE_VALIDATE_TIMESTAMPS=1 playsportsgroup/php:7.2-fpm sh
 
 
 ## Credit
 
-Lots of inspiration from the work on [https://github.com/meanbee/docker-magento2](meanbee/docker-magento2), and internal work I have completed at [Play Sports Network](https://www.playsportsnetwork.com).
+Lots of inspiration from the work on [https://github.com/meanbee/docker-magento2](meanbee/docker-magento2), and internal work completed at [Play Sports Network](https://www.playsportsnetwork.com).

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -35,10 +35,7 @@ RUN DOCKERIZE_URL="https://circle-downloads.s3.amazonaws.com/circleci-images/cac
   && rm -rf /tmp/dockerize-linux-amd64.tar.gz \
   && dockerize --version
 
-RUN adduser -D -g 1000 -u 1000 -h /var/www -s /bin/bash app && \
-  mkdir -p /var/www/html /var/www/bin && \
-  chown -R app:app /var/www /var/www/html /var/www/bin
+RUN mkdir -p /var/www/html /var/www/bin
 
-USER app:app
 WORKDIR /var/www/html
 ENV PATH /var/www/bin:$PATH

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,25 +3,8 @@ version: "2.1"
 services:
 
 ##################################
-# CLI Versions: 7.1, 7.2, 7.3 #
+# CLI Versions: 7.2, 7.3 #
 ##################################
-  php-71-cli:
-    image: playsportsgroup/php:7.1-cli-alpine-root${BRANCH}
-    build:
-      context: .
-      args:
-        VERSION: "7.1"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath pcntl mcrypt opcache"
-        FLAVOUR: alpine
-      dockerfile: cli/Dockerfile
-
-  php-71-cli-xdebug:
-    extends:
-      service: php-71-cli
-    image: playsportsgroup/php:7.1-cli-xdebug-alpine-root${BRANCH}
-    build:
-      args:
-        XDEBUG: 1
 
   php-72-cli:
     image: playsportsgroup/php:7.2-cli-alpine-root${BRANCH}
@@ -60,25 +43,8 @@ services:
         XDEBUG: 1
 
 ##################################
-# FPM Versions: 7.1, 7.2, 7.3 #
+# FPM Versions: 7.2, 7.3 #
 ##################################
-  php-71-fpm:
-    image: ashsmith/php:7.1-fpm-alpine-root${BRANCH}
-    build:
-      context: .
-      args:
-        VERSION: "7.1"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath pcntl mcrypt opcache"
-        FLAVOUR: alpine
-      dockerfile: fpm/Dockerfile
-
-  php-71-fpm-xdebug:
-    extends:
-      service: php-71-fpm
-    image: ashsmith/php:7.1-fpm-xdebug-alpine-root${BRANCH}
-    build:
-      args:
-        XDEBUG: 1
 
   php-72-fpm:
     image: playsportsgroup/php:7.2-fpm-alpine-root${BRANCH}
@@ -107,7 +73,6 @@ services:
         PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
         FLAVOUR: alpine
       dockerfile: fpm/Dockerfile
-    image: playsportsgroup/php:7.3-fpm-xdebug-alpine-root${BRANCH}
 
   php-73-fpm-xdebug:
     extends:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 # CLI Versions: 7.1, 7.2, 7.3 #
 ##################################
   php-71-cli:
-    image: playsportsgroup/php:7.1-cli-alpine${BRANCH}
+    image: playsportsgroup/php:7.1-cli-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -18,13 +18,13 @@ services:
   php-71-cli-xdebug:
     extends:
       service: php-71-cli
-    image: playsportsgroup/php:7.1-cli-xdebug-alpine${BRANCH}
+    image: playsportsgroup/php:7.1-cli-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1
 
   php-72-cli:
-    image: playsportsgroup/php:7.2-cli-alpine${BRANCH}
+    image: playsportsgroup/php:7.2-cli-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -36,13 +36,13 @@ services:
   php-72-cli-xdebug:
     extends:
       service: php-72-cli
-    image: playsportsgroup/php:7.2-cli-xdebug-alpine${BRANCH}
+    image: playsportsgroup/php:7.2-cli-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1
 
   php-73-cli:
-    image: ashsmith/php:7.3-cli-alpine${BRANCH}
+    image: ashsmith/php:7.3-cli-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -54,7 +54,7 @@ services:
   php-73-cli-xdebug:
     extends:
       service: php-73-cli
-    image: ashsmith/php:7.3-cli-xdebug-alpine${BRANCH}
+    image: ashsmith/php:7.3-cli-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1
@@ -63,7 +63,7 @@ services:
 # FPM Versions: 7.1, 7.2, 7.3 #
 ##################################
   php-71-fpm:
-    image: ashsmith/php:7.1-fpm-alpine${BRANCH}
+    image: ashsmith/php:7.1-fpm-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -75,13 +75,13 @@ services:
   php-71-fpm-xdebug:
     extends:
       service: php-71-fpm
-    image: ashsmith/php:7.1-fpm-xdebug-alpine${BRANCH}
+    image: ashsmith/php:7.1-fpm-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1
 
   php-72-fpm:
-    image: playsportsgroup/php:7.2-fpm-alpine${BRANCH}
+    image: playsportsgroup/php:7.2-fpm-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -93,13 +93,13 @@ services:
   php-72-fpm-xdebug:
     extends:
       service: php-72-fpm
-    image: playsportsgroup/php:7.2-fpm-xdebug-alpine${BRANCH}
+    image: playsportsgroup/php:7.2-fpm-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1
 
   php-73-fpm:
-    image: playsportsgroup/php:7.3-fpm-alpine${BRANCH}
+    image: playsportsgroup/php:7.3-fpm-alpine-root${BRANCH}
     build:
       context: .
       args:
@@ -107,12 +107,12 @@ services:
         PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
         FLAVOUR: alpine
       dockerfile: fpm/Dockerfile
-    image: playsportsgroup/php:7.3-fpm-xdebug-alpine${BRANCH}
+    image: playsportsgroup/php:7.3-fpm-xdebug-alpine-root${BRANCH}
 
   php-73-fpm-xdebug:
     extends:
       service: php-73-fpm
-    image: playsportsgroup/php:7.3-fpm-xdebug-alpine${BRANCH}
+    image: playsportsgroup/php:7.3-fpm-xdebug-alpine-root${BRANCH}
     build:
       args:
         XDEBUG: 1

--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -22,19 +22,15 @@ RUN apk add --no-cache \
 
 RUN if [ "$XDEBUG" = "1" ]; then pecl install -o -f xdebug && docker-php-ext-enable xdebug; fi
 
-RUN adduser -D -g 1000 -u 1000 -h /var/www -s /bin/bash app && \
-  mkdir -p /var/www/html /var/www/bin && \
-  chown -R app:app /var/www /var/www/html /var/www/bin
+RUN mkdir -p /var/www/html /var/www/bin
 
 # A few sensible defaults.
 COPY fpm/config/php-fpm.conf /usr/local/etc/
 COPY fpm/config/opcache.ini /usr/local/etc/php/conf.d/aa-opcache.ini
 RUN touch /usr/local/etc/php/conf.d/opcache.blacklist
-USER app:app
 
 WORKDIR /var/www/html
 
-# You can add scripts into here that will be owned by app and available in your PATH.
 ENV PATH /var/www/bin:$PATH
 
-CMD ["php-fpm", "-F"]
+CMD ["php-fpm", "-F", "-R"]

--- a/fpm/config/php-fpm.conf
+++ b/fpm/config/php-fpm.conf
@@ -8,12 +8,8 @@ daemonize = no
 ; if we send this to /proc/self/fd/1, it never appears
 access.log = /proc/self/fd/2
 
-;user = app
-;group = app
-
 listen = [::]:9000
-listen.owner = app
-listen.group = app
+
 listen.mode = 0660
 
 pm = dynamic

--- a/fpm/config/www.conf
+++ b/fpm/config/www.conf
@@ -20,8 +20,8 @@
 ; Unix user/group of processes
 ; Note: The user is mandatory. If the group is not set, the default user's group
 ;       will be used.
-user = app
-group = app
+user = root
+group = root
 
 ; The address on which to accept FastCGI requests.
 ; Valid syntaxes are:


### PR DESCRIPTION
I've added a new image tag which moves away from using non-root users `playsportsgroup/php:7.2-fpm-alpine-root`. Main purpose is to workaround issues we've experienced inside of kubernetes with volume mounts and file ownership.

I've also deprecated php 7.1 from our list of images, as it will become EOL in December and is currently only receiving security patches. None of our projects use 7.1 anymore.