### PR TITLE
Adds pcntl extension

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       context: .
       args:
         VERSION: "7.2"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache pcntl"
         FLAVOUR: alpine
       dockerfile: cli/Dockerfile
 
@@ -30,7 +30,7 @@ services:
       context: .
       args:
         VERSION: "7.3"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache pcntl"
         FLAVOUR: alpine
       dockerfile: cli/Dockerfile
 
@@ -52,7 +52,7 @@ services:
       context: .
       args:
         VERSION: "7.2"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache pcntl"
         FLAVOUR: alpine
       dockerfile: fpm/Dockerfile
 
@@ -70,7 +70,7 @@ services:
       context: .
       args:
         VERSION: "7.3"
-        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache"
+        PHP_EXTENSIONS: "dom gd intl mbstring pdo_mysql xsl zip soap bcmath opcache pcntl"
         FLAVOUR: alpine
       dockerfile: fpm/Dockerfile
 


### PR DESCRIPTION
pcntl is a process control extension for php. Frameworks like laravel and cms's like  magento uses this extension to fork processes.

For example. Magento uses it to parallelise the `bin/magento setup:static-content:deploy` command for example.